### PR TITLE
Fix label on technology migration

### DIFF
--- a/migrations/Version20240108222751CreateTechnologiesTable.php
+++ b/migrations/Version20240108222751CreateTechnologiesTable.php
@@ -3,7 +3,7 @@
 use Bow\Database\Migration\Migration;
 use Bow\Database\Migration\SQLGenerator;
 
-class Version20240108222751CreateTechnologysTable extends Migration
+class Version20240108222751CreateTechnologiesTable extends Migration
 {
     /**
      * Run the migrations.
@@ -32,6 +32,6 @@ class Version20240108222751CreateTechnologysTable extends Migration
      */
     public function rollback(): void
     {
-        $this->dropIfExists('categories');
+        $this->dropIfExists('technologies');
     }
 }


### PR DESCRIPTION
Hello !
Good project, I will try to contribute according to my availability, and it will allow me to discover the framework :)

Installation Ok, but during the execution of the migration command:
**php bow migrate --seed**

There is an error at the class level: Version20240108222751CreateTechnologiesTable

Best regards